### PR TITLE
README.md changes

### DIFF
--- a/msteams-ui-styles-core/README.md
+++ b/msteams-ui-styles-core/README.md
@@ -22,7 +22,7 @@ const { style } = require('typestyle/lib')
 // This function is optional. The default one will use Typestyle.
 // 'name' is the advised potential name of the class, your function can ignore this and return anything.
 // 'cssProperties' is the object containing the css properties to generate the class from.
-const cssFunction = (name, cssProperties) => {
+const cssFunction = (name, ...cssProperties) => {
   // default typestyle styling function.
   return style(...cssProperties);
 }


### PR DESCRIPTION
An error has been detected in the README.md example in msteams-ui-styles-core.
Indeed, the parameter cssproperties is sent as an array of parameters (varargs),
so it is natural to get it as an array as well.