### PR TITLE
For IconButtons make iconWeight default not override 0 option

### DIFF
--- a/msteams-ui-components-react/src/buttons/icon.tsx
+++ b/msteams-ui-components-react/src/buttons/icon.tsx
@@ -37,7 +37,7 @@ class IconButtonView
   }
 
   render() {
-    const { context, className, iconType, iconWeight, children, onRef, ...rest } = this.props;
+    const { context, className, iconType, iconWeight = MSTeamsIconWeight.Light, children, onRef, ...rest } = this.props;
     const themeClassName = iconButton(context);
 
     return <button
@@ -46,7 +46,7 @@ class IconButtonView
       onMouseDown={(e) => e.preventDefault()}
       className={classes(themeClassName, className)}
       {...rest}>
-      <MSTeamsIcon iconType={iconType} iconWeight={iconWeight || MSTeamsIconWeight.Light} />
+      <MSTeamsIcon iconType={iconType} iconWeight={ iconWeight } />
       {children}
     </button>;
   }

--- a/msteams-ui-components-react/src/buttons/icon.tsx
+++ b/msteams-ui-components-react/src/buttons/icon.tsx
@@ -46,7 +46,7 @@ class IconButtonView
       onMouseDown={(e) => e.preventDefault()}
       className={classes(themeClassName, className)}
       {...rest}>
-      <MSTeamsIcon iconType={iconType} iconWeight={ iconWeight } />
+      <MSTeamsIcon iconType={iconType} iconWeight={iconWeight} />
       {children}
     </button>;
   }


### PR DESCRIPTION
Fixes #184 

Because MSTeamsIconWeight.Regular = 0 when you use iconWeight || MSTeamsIconWeight.Light you can never get the regular weight