### PR TITLE
Updated for Nonce implementation while refereing typestyle

### DIFF
--- a/msteams-ui-styles-core/src/components/input.ts
+++ b/msteams-ui-styles-core/src/components/input.ts
@@ -1,7 +1,15 @@
-import { keyframes } from 'typestyle';
 import { chooseStyle, IContext } from '../context';
 import { errorLabel } from '../index';
 import { label } from './label';
+import { setStylesTarget , keyframes } from 'typestyle';
+
+const target = document.createElement('style');
+target.setAttribute('nonce', 'cmFuZG9tIG51bWJlcg=='); //This is a base64 encoded random number which can be added in the csp header as nonce value
+if(document.head) {
+    document.head.appendChild(target);
+}
+
+setStylesTarget(target);
 
 interface IInputColors {
   rest: {


### PR DESCRIPTION
While implementation for Content-Security-Policy header, inline styles are not accepted.
Here typestyle generates inline styles when refered
Adding a nonce to the style as an attribute and match the same nonce in the CSP header solves this issue

This Pull request is raised against the issue: 
https://github.com/OfficeDev/msteams-ui-components/issues/192