### PR TITLE
Add selected property to dropdown component.

### DIFF
--- a/msteams-ui-components-react/src/dropdown/dropdown.tsx
+++ b/msteams-ui-components-react/src/dropdown/dropdown.tsx
@@ -13,6 +13,7 @@ export interface IDropdownProps
   mainButtonText?: string;
   label?: string;
   items: IDropdownItemProps[];
+  selected?: string;
 }
 
 export interface IDropdownItemProps {
@@ -66,6 +67,7 @@ class DropdownInternal extends React.Component<IDropdownProps & ITeamsThemeConte
       mainButtonText,
       style,
       items,
+      selected,
       // tslint:disable-next-line:trailing-comma
       ...rest
     } = this.props;
@@ -132,7 +134,15 @@ class DropdownInternal extends React.Component<IDropdownProps & ITeamsThemeConte
 
   private open = () => {
     if (this.mounted) {
-      this.setState({ show: true }, this.focusNext);
+      this.setState({ show: true }, () => {
+        if (!this.props.selected) {
+          return
+        }
+        const selected = this.itemButtons.findIndex((elm) => elm.text() === this.props.selected);
+        if (selected >= 0) {
+          return this.itemButtons[selected].focus();
+        }
+      });
       document.addEventListener('click', this.close);
     }
   }

--- a/msteams-ui-components-react/src/dropdown/item.tsx
+++ b/msteams-ui-components-react/src/dropdown/item.tsx
@@ -19,6 +19,10 @@ export class DropdownItem extends React.Component<IDropdownItemProps>
     return !!this.button && this.button === document.activeElement;
   }
 
+  text = (): string | undefined => {
+    return this.props.text;
+  }
+
   focus = () => {
     if (this.button) {
       this.button.focus();


### PR DESCRIPTION
This PR adds a `selected` property to the dropdown component.  This property can be used to control which option is selected when the dropdown is opened.  The `selected` property expects a string value, this value is matched against each item's text property - the first match will be selected.

⚠️ **This PR introduces a change to the existing behaviour as mentioned in issue [#202](https://github.com/OfficeDev/msteams-ui-components/issues/202#issuecomment-505033559)**

Prior to this PR, the first option was always selected when a dropdown was opened.  With this PR, that is no longer the case.  If you want the first option to be selected you must now specify that option using the new `selected` property.
